### PR TITLE
assign admission encounter during bed-patient assignment

### DIFF
--- a/src/bed-admission/active-patients/active-patients-table.component.tsx
+++ b/src/bed-admission/active-patients/active-patients-table.component.tsx
@@ -119,7 +119,7 @@ const ActivePatientsTable: React.FC<ActiveVisitsTableProps> = ({
       },
       {
         id: 1,
-        header: t("idNumber", "ID Number"),
+        header: t("idNumber", "Identifier"),
         key: "idNumber",
       },
       {
@@ -160,7 +160,7 @@ const ActivePatientsTable: React.FC<ActiveVisitsTableProps> = ({
         ),
       },
     }));
-  }, [paginatedQueueEntries, status, t, renderActionButton, fromPage]);
+  }, [paginatedQueueEntries, renderActionButton]);
 
   if (isLoading) {
     return <DataTableSkeleton role="progressbar" />;

--- a/src/bed-admission/active-patients/active-visits.resource.ts
+++ b/src/bed-admission/active-patients/active-visits.resource.ts
@@ -91,7 +91,7 @@ export function useActiveVisits() {
     ) {
       setSize((currentSize) => currentSize + 1);
     }
-  }, [data, pageNumber]);
+  }, [data, pageNumber, setSize]);
 
   const mapVisitProperties = (visit: Visit): ActiveVisit => {
     // create base object

--- a/src/bed-admission/admitted-patients/active-admissions.resource.ts
+++ b/src/bed-admission/admitted-patients/active-admissions.resource.ts
@@ -18,6 +18,10 @@ interface VisitResponse {
   totalCount: number;
 }
 
+// interface SQLBedAssignmentResponse {
+
+// }
+
 export interface BedPatientAssignment {
   patientUuid: string;
   age: number;
@@ -71,7 +75,7 @@ export function useActiveAdmissions() {
     ) {
       setSize((currentSize) => currentSize + 1);
     }
-  }, [data, pageNumber]);
+  }, [data, pageNumber, setSize]);
 
   const formattedActiveVisits: any = (data: FetchResponse<VisitResponse>) => {
     const result = data

--- a/src/bed-admission/admitted-patients/admitted-patients-table.component.tsx
+++ b/src/bed-admission/admitted-patients/admitted-patients-table.component.tsx
@@ -91,7 +91,7 @@ const AdmittedPatientsTable: React.FC<ActiveVisitsTableProps> = ({
       //   />
       // );
     },
-    [handleBedAssigmentModal, status]
+    [status]
   );
 
   const {
@@ -148,7 +148,7 @@ const AdmittedPatientsTable: React.FC<ActiveVisitsTableProps> = ({
         ),
       },
     }));
-  }, [paginatedQueueEntries, status, t, renderActionButton, fromPage]);
+  }, [paginatedQueueEntries]);
 
   if (isLoading) {
     return <DataTableSkeleton role="progressbar" />;

--- a/src/bed-admission/bed-admission.resource.ts
+++ b/src/bed-admission/bed-admission.resource.ts
@@ -1,4 +1,6 @@
-import { FetchResponse, openmrsFetch } from "@openmrs/esm-framework";
+import { FetchResponse, openmrsFetch, useConfig } from "@openmrs/esm-framework";
+import { useMemo } from "react";
+import useSWR from "swr";
 
 export async function assignPatientBed(
   requestPayload,
@@ -32,4 +34,19 @@ export async function endPatientQueue(
     }
   );
   return response;
+}
+
+export function findLatestClinicalEncounter(
+  patientUuid: string,
+  encounterTypeUuid: string,
+  data,
+  admissionFormUuid
+) {
+  const clinicalEncounters =
+    data?.data?.results?.filter(
+      (enc) => enc?.form?.uuid === admissionFormUuid
+    ) ?? [];
+  const encounterUuid = clinicalEncounters?.[0]?.uuid ?? "";
+
+  return { data: encounterUuid };
 }

--- a/src/bed-admission/bed-layout/bed-layout-list.component.tsx
+++ b/src/bed-admission/bed-layout/bed-layout-list.component.tsx
@@ -53,7 +53,7 @@ const BedLayoutList: React.FC<BedLayoutListProps> = React.memo(
       );
     }
 
-    if (locationUuid === undefined) {
+    if (locationUuid === "") {
       return (
         <div className={styles.errorContainer}>
           <EmptyState
@@ -63,7 +63,7 @@ const BedLayoutList: React.FC<BedLayoutListProps> = React.memo(
         </div>
       );
     }
-    if (locationUuid !== undefined && !bedData?.length) {
+    if (locationUuid !== "" && !bedData?.length) {
       return (
         <div className={styles.errorContainer}>
           <EmptyState

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -14,8 +14,18 @@ export const configSchema = {
     _default: "a73e2ac6-263b-47fc-99fc-e0f2c09fc914",
   },
   restrictWardAdministrationToLoginLocation: {
-    _type: boolean,
+    _type: Type.Boolean,
     _description: "UUID for the inpatient visit",
     _default: false,
+  },
+  admissionEncounterTypeUuid: {
+    _type: Type.String,
+    _description: "UUID for the encounter type to use for admission",
+    _default: "465a92f2-baf8-42e9-9612-53064be868e8",
+  },
+  admissionFormUuid: {
+    _type: Type.String,
+    _description: "UUID for the admission form",
+    _default: "e958f902-64df-4819-afd4-7fb061f59308",
   },
 };

--- a/src/workspace/allocate-bed.scss
+++ b/src/workspace/allocate-bed.scss
@@ -115,3 +115,10 @@
   opacity: 0.8;
   pointer-events: none;
 }
+
+.missingEncounter {
+  @include type.type-style('heading-compact-01');
+  color: $text-02;
+  margin-top: spacing.$spacing-05;
+  margin-bottom: spacing.$spacing-03;
+}


### PR DESCRIPTION
This PR assigns the required encounter for admission during bed-patient assignment. The save button is disabled if the required encounter doesn't exist. 
NOTE: There needs to be an additional logic to limit the encounters to a particular date range i.e. within the same day. This will be in a follow-up PR